### PR TITLE
Retirement UI - create2

### DIFF
--- a/retirement-ui/src/app/providers.tsx
+++ b/retirement-ui/src/app/providers.tsx
@@ -92,6 +92,7 @@ export interface AppState {
 export interface Actions {
     setStep: (newStep: number) => void;
     setHoldingContractTarget: (newTarget: Address) => void;
+    clearHoldingContractTarget: () => void;
     updateActiveUSDCBridgeTransaction: (newTx: Partial<BridgeTransaction>) => void;
     clearActiveUSDCBridgeTransaction: () => void;
     updateActiveRetirementCertificateBridgeTransaction: (newTx: Partial<BridgeTransaction>) => void;
@@ -116,6 +117,7 @@ export const useAppStore = create<AppState & Actions>()(
 
                     holdingContractTarget: undefined,
                     setHoldingContractTarget: (newTarget: Address) => set(() => ({holdingContractTarget: newTarget})),
+                    clearHoldingContractTarget: () => set(() => ({holdingContractTarget: undefined})),
 
                     activeUSDCBridgeTransaction: undefined,
                     updateActiveUSDCBridgeTransaction:

--- a/retirement-ui/src/hooks/holdingContract/useHoldingContract.ts
+++ b/retirement-ui/src/hooks/holdingContract/useHoldingContract.ts
@@ -14,6 +14,7 @@ import {HOLDING_CONTRACT_ABI} from "@/lib/abi/holdingContract";
 export const useHoldingContract = () => {
     const holdingContractTarget = useAppStore(state => state.holdingContractTarget);
     const setHoldingContractTarget = useAppStore(state => state.setHoldingContractTarget);
+    const clearHoldingContractTarget = useAppStore(state => state.clearHoldingContractTarget);
 
     const setRetirementNFTs = useAppStore(state => state.setRetirementNFTs);
 
@@ -58,6 +59,8 @@ export const useHoldingContract = () => {
     useEffect(() => {
         if (factory?.contractAddress) {
             setHoldingContractTarget(factory.contractAddress)
+        } else if (!factory.contractAddress && !factory.isError) {
+            clearHoldingContractTarget()
         }
     }, [factory?.contractAddress])
 

--- a/retirement-ui/src/lib/constants.ts
+++ b/retirement-ui/src/lib/constants.ts
@@ -1,5 +1,5 @@
 import {Cluster, PublicKey} from "@solana/web3.js";
-import {padHex} from "viem";
+import {keccak256, Hex} from "viem";
 
 // Endpoints, connection
 export const ENV: Cluster = (process.env.CLUSTER as Cluster) || "mainnet-beta";
@@ -88,5 +88,8 @@ export interface JupiterToken {
     tags: string[]; // [ 'utility-token', 'capital-token' ]
 }
 
-export const HOLDING_CONTRACT_FACTORY_SALT = padHex(`0x${Buffer.from("sunrise-v0.0.2").toString("hex")}`);
+export const holdingContractFactorySalt = (address:string): Hex => {
+    const unhashedSalt = `sunrise-v0.0.2${address}`
+    return keccak256(Buffer.from(unhashedSalt), 'hex');
+}
 


### PR DESCRIPTION
Fix holding contract creation to include the caller's wallet as part of the create2 salt, ensuring different addresses for each wallet